### PR TITLE
Update index.njk - Vite version

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -18,9 +18,9 @@ eleventyNavigation:
     <section class="list">
       <h2>Features</h2>
         <ul dir="auto">
-          <li>Eleventy 2.0.0-canary</li>
+          <li>Eleventy 2.0.1</li>
           <li>New Eleventy 2.0 Dev Server with live reload</li>
-          <li>Vite 3.0 as Middleware in Eleventy Dev Server (uses <a href="https://github.com/11ty/eleventy-plugin-vite/">eleventy-plugin-vite</a>)</li>
+          <li>Vite 4.5.0 as Middleware in Eleventy Dev Server (uses <a href="https://github.com/11ty/eleventy-plugin-vite/">eleventy-plugin-vite</a>)</li>
           <li>Eleventy build output is post-processed by <a href="https://vitejs.dev" rel="nofollow">Vite</a> (with Rollup)</li>
           <li>CSS/Sass post-processing with PostCSS incl. <a href="https://github.com/postcss/autoprefixer">Autoprefixer</a> and cssnano</li>
           <li>Uses <a href="https://matthiasott.com/notes/how-i-structure-my-css" rel="nofollow">my own opinionated CSS/Sass structure</a></li>


### PR DESCRIPTION
Hey,

just checked the demo site and thought "Oh, I would have to update Vite myself". But just saw that 4.5.0 is already included :+1: